### PR TITLE
Replace SSH deploy with AWS SSM

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,14 +9,55 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.3
-        timeout-minutes: 3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd ~/Bargainista
-            git pull origin main
-            docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Deploy via SSM
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --timeout-seconds 600 \
+            --parameters 'commands=["cd ~/Bargainista && git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: $COMMAND_ID"
+
+          for i in $(seq 1 72); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+
+            echo "[$i] Status: $STATUS"
+
+            case "$STATUS" in
+              Success)
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                  --query "StandardOutputContent" \
+                  --output text
+                exit 0
+                ;;
+              Failed|Cancelled|TimedOut|DeliveryTimedOut|ExecutionTimedOut)
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                  --query "[StandardOutputContent, StandardErrorContent]" \
+                  --output text
+                exit 1
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          echo "Deploy timed out after 12 minutes"
+          exit 1


### PR DESCRIPTION
## Summary

- Replaces `appleboy/ssh-action` (SSH over port 22) with AWS SSM `send-command`
- Eliminates the need to open port 22 on the EC2 security group to the public internet
- Polls for command completion every 10 seconds, up to 12 minutes, and surfaces stdout/stderr in the Actions log

## Why

GitHub Actions runners come from GitHub's dynamic IP pool. The EC2 security group had port 22 restricted to a single IP, which permanently blocked every deploy run with an `i/o timeout`.

SSM send-command tunnels through the AWS control plane — no inbound port required on the instance at all. The instance authenticates via its IAM instance profile (`AmazonSSMManagedInstanceCore`); the Actions runner authenticates via a dedicated IAM user with `AmazonSSMFullAccess`.

## Secrets required (one-time setup)

| Secret | Description |
|---|---|
| `AWS_ACCESS_KEY_ID` | IAM user credentials for GitHub Actions |
| `AWS_SECRET_ACCESS_KEY` | IAM user credentials for GitHub Actions |
| `AWS_REGION` | `us-east-2` |
| `EC2_INSTANCE_ID` | Instance ID (e.g. `i-0abc1234def567890`) |

Old secrets `EC2_HOST` and `EC2_SSH_KEY` can be removed after this merges.

## Test plan

- [ ] Merge triggers deploy workflow
- [ ] SSM command ID appears in Actions log
- [ ] Polling loop reaches `Success` status
- [ ] Docker compose output visible in Actions log
- [ ] bargainista.io still live after deploy completes