### PR TITLE
Fix SSM deploy path

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
             --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 600 \
-            --parameters 'commands=["cd ~/Bargainista && git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
+            --parameters 'commands=["cd /home/ec2-user/Bargainista && git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
             --query "Command.CommandId" \
             --output text)
 


### PR DESCRIPTION
## Summary

- Changes `~/Bargainista` to `/home/ec2-user/Bargainista` in the SSM send-command script

## Why

SSM agent runs commands as `root`, so `~` expands to `/root/` rather than `/home/ec2-user/`. The deploy was failing immediately with `cd: /root/Bargainista: No such file or directory`.