### PR TITLE
Fix git safe.directory error in SSM deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
             --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 600 \
-            --parameters 'commands=["cd /home/ec2-user/Bargainista && git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
+            --parameters 'commands=["git config --global --add safe.directory /home/ec2-user/Bargainista && cd /home/ec2-user/Bargainista && git pull origin main && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
             --query "Command.CommandId" \
             --output text)
 


### PR DESCRIPTION
## Summary

- Prepends `git config --global --add safe.directory /home/ec2-user/Bargainista` to the deploy script

## Why

SSM runs commands as `root`, but the repo directory is owned by `ec2-user`. Git 2.35+ treats this as a security risk and refuses to operate with `fatal: detected dubious ownership in repository`. Adding the directory to `root`'s safe.directory list tells Git the ownership mismatch is intentional.