### PR TITLE
Add on-demand EC2 diagnostics workflow

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -1,0 +1,62 @@
+name: EC2 Diagnostics
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Fetch container state and logs
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+            --document-name "AWS-RunShellScript" \
+            --timeout-seconds 60 \
+            --parameters 'commands=[
+              "cd /home/ec2-user/Bargainista",
+              "echo === CONTAINER STATUS ===",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml ps",
+              "echo === API LOGS (last 50 lines) ===",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs api --tail 50",
+              "echo === WORKER LOGS (last 20 lines) ===",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs worker --tail 20",
+              "echo === NGINX LOGS (last 20 lines) ===",
+              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs nginx --tail 20"
+            ]' \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "Command ID: $COMMAND_ID"
+
+          for i in $(seq 1 12); do
+            STATUS=$(aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+              --query "Status" \
+              --output text 2>/dev/null || echo "Pending")
+            echo "[$i] $STATUS"
+            case "$STATUS" in
+              Success|Failed|Cancelled|TimedOut|DeliveryTimedOut|ExecutionTimedOut)
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                  --query "StandardOutputContent" \
+                  --output text
+                aws ssm get-command-invocation \
+                  --command-id "$COMMAND_ID" \
+                  --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
+                  --query "StandardErrorContent" \
+                  --output text
+                break
+                ;;
+            esac
+            sleep 5
+          done


### PR DESCRIPTION
Adds `workflow_dispatch` diagnostics workflow — fetches container status and last 50 lines of API/worker/nginx logs from EC2 via SSM. Triggered manually from the Actions tab, not on push.

Needed now to diagnose the 502 on bargainista.io.