### PR TITLE
Add restart policy to api/worker, fix diagnostics script

### DIFF
--- a/.github/workflows/diagnostics.yml
+++ b/.github/workflows/diagnostics.yml
@@ -20,17 +20,7 @@ jobs:
             --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 60 \
-            --parameters 'commands=[
-              "cd /home/ec2-user/Bargainista",
-              "echo === CONTAINER STATUS ===",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml ps",
-              "echo === API LOGS (last 50 lines) ===",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs api --tail 50",
-              "echo === WORKER LOGS (last 20 lines) ===",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs worker --tail 20",
-              "echo === NGINX LOGS (last 20 lines) ===",
-              "docker compose -f docker-compose.yml -f docker-compose.prod.yml logs nginx --tail 20"
-            ]' \
+            --parameters 'commands=["cd /home/ec2-user/Bargainista && echo === CONTAINER STATUS === && docker compose -f docker-compose.yml -f docker-compose.prod.yml ps --all && echo === API LOGS === && docker compose -f docker-compose.yml -f docker-compose.prod.yml logs api --tail 50 && echo === WORKER LOGS === && docker compose -f docker-compose.yml -f docker-compose.prod.yml logs worker --tail 20 && echo === NGINX LOGS === && docker compose -f docker-compose.yml -f docker-compose.prod.yml logs nginx --tail 20"]' \
             --query "Command.CommandId" \
             --output text)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,7 @@ services:
     env_file:
       - path: .env
         required: false      # API keys live here; stack still starts without them
+    restart: unless-stopped
 
   mcp:
     build:
@@ -76,6 +77,7 @@ services:
     env_file:
       - path: .env
         required: false
+    restart: unless-stopped
 
   redis:
     image: redis:7-alpine


### PR DESCRIPTION
- `restart: unless-stopped` on api and worker — if either crashes, Docker restarts them automatically instead of leaving the site dead until the next deploy
- Fixes diagnostics workflow SSM script: parentheses in echo commands broke bash parsing; rewritten as a single inline command string