### PR TITLE
Fix nginx DNS staleness after deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
             --instance-id "${{ secrets.EC2_INSTANCE_ID }}" \
             --document-name "AWS-RunShellScript" \
             --timeout-seconds 600 \
-            --parameters 'commands=["export HOME=/root","git config --global --add safe.directory /home/ec2-user/Bargainista","cd /home/ec2-user/Bargainista","git pull origin main","docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1"]' \
+            --parameters 'commands=["export HOME=/root","git config --global --add safe.directory /home/ec2-user/Bargainista","cd /home/ec2-user/Bargainista","git pull origin main","docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build 2>&1","docker compose -f docker-compose.yml -f docker-compose.prod.yml restart nginx"]' \
             --query "Command.CommandId" \
             --output text)
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,13 +1,15 @@
-upstream api {
-    server api:8000;
-}
-
 server {
     listen 80;
     server_name bargainista.io www.bargainista.io _;
 
+    # 127.0.0.11 is Docker's embedded DNS resolver.
+    # valid=10s forces re-resolution every 10s so nginx picks up new container IPs
+    # after a deploy without needing a restart.
+    resolver 127.0.0.11 valid=10s;
+
     location / {
-        proxy_pass         http://api;
+        set $upstream http://api:8000;
+        proxy_pass         $upstream;
         proxy_http_version 1.1;
 
         # Required for WebSocket upgrade negotiation (/ws/analyze/{run_id}).


### PR DESCRIPTION
nginx resolves upstream hostnames at startup and caches them. When api/worker containers are recreated they get new Docker-internal IPs, but nginx keeps pointing at the old dead IPs → 502.

Two fixes:
- **nginx.conf**: drop the `upstream` block, add `resolver 127.0.0.11 valid=10s` (Docker's embedded DNS) + `set $upstream http://api:8000` so nginx re-resolves every 10s dynamically
- **deploy.yml**: `docker compose restart nginx` after every `up -d --build` as a belt-and-suspenders guarantee

Merging this will trigger a deploy that restarts nginx and brings bargainista.io back up.