### PR TITLE
add history document upload

### DIFF
--- a/app/agents/history.py
+++ b/app/agents/history.py
@@ -462,7 +462,7 @@ async def run(listing: ListingInput) -> HistoryAgentResult:
 
     response = await client.messages.create(  # type: ignore[call-overload]
         model="claude-sonnet-4-6",
-        max_tokens=2048,
+        max_tokens=4096,
         system=_SYSTEM_PROMPT,
         tools=[_HISTORY_TOOL],  # type: ignore[list-item]
         tool_choice={"type": "tool", "name": "history_analysis"},
@@ -488,13 +488,13 @@ async def run(listing: ListingInput) -> HistoryAgentResult:
     repair_mentions = [_build_repair_estimate(item) for item in raw.get("repair_mentions", [])]
 
     return HistoryAgentResult(
-        risk_score=raw["risk_score"],
+        risk_score=raw.get("risk_score", 5),
         red_flags=raw.get("red_flags", []),
-        mileage_consistent=raw["mileage_consistent"],
+        mileage_consistent=raw.get("mileage_consistent", True),
         ownership_signals=raw.get("ownership_signals", []),
         accident_mentions=raw.get("accident_mentions", []),
         title_concerns=raw.get("title_concerns", []),
         repair_mentions=repair_mentions,
         data_sources_available=data_sources,  # Python-set — never from LLM
-        summary=raw["summary"],
+        summary=raw.get("summary", "History analysis incomplete — response truncated."),
     )

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -1,7 +1,8 @@
 import json
+import os
 
 import redis.asyncio as aioredis
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, UploadFile
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -10,7 +11,10 @@ from app.db.session import get_db
 from app.mcp.client import call_tool
 from app.models.db_models import AnalysisRun, RunStatus
 from app.models.schemas import ListingInput
+from app.utils.document_processing import process_document
 from app.workers.tasks import run_analysis_task
+
+_ACCEPTED_EXTENSIONS = {".pdf", ".jpg", ".jpeg", ".png", ".webp"}
 
 router = APIRouter()
 
@@ -18,6 +22,33 @@ router = APIRouter()
 @router.get("/health")
 async def health() -> dict:
     return {"status": "ok"}
+
+
+@router.post("/api/process-document")
+async def process_document_upload(file: UploadFile) -> dict:
+    """Extract text from an uploaded PDF or image file.
+
+    Returns the extracted text immediately so the frontend can display per-file
+    status before the user submits the main analysis form. Binary is never
+    forwarded to the analysis pipeline — only the extracted text string is kept.
+    """
+    filename = file.filename or ""
+    ext = os.path.splitext(filename.lower())[1]
+    if ext not in _ACCEPTED_EXTENSIONS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Unsupported file type '{ext or 'none'}'. Accepted: .pdf, .jpg, .jpeg, .png, .webp",
+        )
+
+    content = await file.read()
+    result = await process_document(filename, content)
+
+    return {
+        "success": result["success"],
+        "extracted_text": result["text"] if result["success"] else None,
+        "filename": result["filename"],
+        "error": result["error"],
+    }
 
 
 @router.get("/api/vin/{vin}")

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from enum import Enum
 
-from pydantic import BaseModel, Field, HttpUrl, model_validator
+from pydantic import BaseModel, Field, HttpUrl, field_validator, model_validator
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -213,6 +213,16 @@ class ListingInput(BaseModel):
         description="Free-text from the user describing known issues not visible in photos. "
                     "The user's own words, not the seller's listing copy.",
     )
+
+    @field_validator("history_report_text", "user_damage_notes", "listing_description", mode="before")
+    @classmethod
+    def strip_null_bytes_str(cls, v: object) -> object:
+        return v.replace("\x00", "") if isinstance(v, str) else v
+
+    @field_validator("history_document_texts", mode="before")
+    @classmethod
+    def strip_null_bytes_list(cls, v: object) -> object:
+        return [t.replace("\x00", "") if isinstance(t, str) else t for t in v] if isinstance(v, list) else v
 
     @model_validator(mode="after")
     def vehicle_identity_present(self) -> ListingInput:

--- a/app/models/schemas.py
+++ b/app/models/schemas.py
@@ -197,6 +197,16 @@ class ListingInput(BaseModel):
         description="Base64-encoded images from file uploads",
     )
 
+    # History documents — already-extracted text strings from the frontend.
+    # Each entry is pre-labeled by the frontend: "[Document: filename]\n{extracted_text}".
+    # Ingestion combines these with history_report_text into a single labeled block.
+    # Binary is never sent here — processing happens via POST /api/process-document first.
+    history_document_texts: list[str] = Field(
+        default_factory=list,
+        description="Pre-labeled extracted-text strings from uploaded history documents. "
+                    "Each entry: '[Document: {filename}]\\n{extracted_text}'.",
+    )
+
     # User's own observations — distinct from listing copy, safe to show Vision agent
     user_damage_notes: str | None = Field(
         None,

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -112,6 +112,21 @@
   </button>
   <div id="opt-section" class="hidden space-y-4 mb-5">
     <div><label class="lbl">History Report Text</label><textarea id="history_report_text" rows="3" placeholder="Paste CarFax / AutoCheck content..." class="inp resize-none"></textarea></div>
+
+    <div>
+      <label class="lbl">History documents <span class="text-slate-400 font-normal">(optional)</span></label>
+      <p class="text-xs text-slate-400 mb-2">Upload PDFs or photos of service records, Carfax reports, inspection sheets</p>
+      <button type="button" onclick="document.getElementById('doc-input').click()"
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 border border-slate-200 rounded-lg text-sm text-slate-600 bg-white hover:bg-slate-50 hover:border-slate-300 transition-colors">
+        <svg class="w-4 h-4 text-slate-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"/>
+        </svg>
+        Choose files
+      </button>
+      <input id="doc-input" type="file" multiple accept=".pdf,.jpg,.jpeg,.png,.webp" class="hidden" onchange="handleDocuments(this)" />
+      <div id="doc-chips" class="mt-2 flex flex-wrap gap-2"></div>
+    </div>
+
     <div><label class="lbl">Damage Notes <span class="text-slate-400 font-normal">(satisfies photo requirement)</span></label><textarea id="user_damage_notes" rows="2" placeholder="Describe any visible damage if you can't upload photos..." class="inp resize-none"></textarea></div>
     <div><label class="lbl">Image URLs <span class="text-slate-400 font-normal">(one per line — link to listing images, not photo uploads)</span></label><textarea id="image_urls_text" rows="3" placeholder="https://images.craigslist.org/..." class="inp resize-none" style="font-family:monospace;font-size:.75rem"></textarea></div>
   </div>
@@ -277,6 +292,113 @@
 </div>
 
 <script>
+// ── Document upload state ──────────────────────────────────────────────────
+// Map<chipId: string, {filename: string, extracted_text: string}> — populated on success
+const docTexts = new Map();
+// Map<chipId: string, 'pending' | 'success' | 'failed'> — tracks chip status
+const docStatus = new Map();
+let docIdSeq = 0;
+
+function handleDocuments(input) {
+  const files = Array.from(input.files);
+  input.value = ''; // reset so same file can be re-selected
+  if (!files.length) return;
+  files.forEach(f => {
+    const id = 'doc-' + (++docIdSeq);
+    docStatus.set(id, 'pending');
+    renderChip(id, f.name, 'pending');
+    updateSubmitState();
+    processDoc(id, f);
+  });
+}
+
+function renderChip(id, filename, status, errorMsg) {
+  const container = document.getElementById('doc-chips');
+  // remove existing chip with this id if re-rendering
+  const existing = document.getElementById(id);
+  if (existing) existing.remove();
+
+  const chip = document.createElement('div');
+  chip.id = id;
+  chip.className = 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border ' +
+    (status === 'success' ? 'bg-green-50 border-green-200 text-green-800' :
+     status === 'failed'  ? 'bg-red-50 border-red-200 text-red-800' :
+                            'bg-slate-50 border-slate-200 text-slate-700');
+
+  const nameSpan = document.createElement('span');
+  nameSpan.className = 'max-w-[160px] truncate';
+  nameSpan.textContent = filename;
+
+  const iconSpan = document.createElement('span');
+  if (status === 'pending') {
+    iconSpan.innerHTML = '<svg class="w-3 h-3 spin text-blue-500" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z"/></svg>';
+  } else if (status === 'success') {
+    iconSpan.className = 'text-green-600';
+    iconSpan.textContent = '✓';
+  } else {
+    iconSpan.className = 'text-red-600';
+    iconSpan.textContent = '✗';
+  }
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'ml-0.5 text-slate-400 hover:text-slate-600 leading-none';
+  removeBtn.textContent = '×';
+  removeBtn.onclick = () => removeChip(id);
+
+  chip.appendChild(nameSpan);
+  chip.appendChild(iconSpan);
+  if (status === 'failed' && errorMsg) {
+    const errSpan = document.createElement('span');
+    errSpan.className = 'text-red-500';
+    errSpan.textContent = errorMsg.length > 40 ? errorMsg.slice(0, 40) + '…' : errorMsg;
+    chip.appendChild(errSpan);
+  }
+  chip.appendChild(removeBtn);
+  container.appendChild(chip);
+}
+
+function removeChip(id) {
+  const el = document.getElementById(id);
+  if (el) el.remove();
+  docTexts.delete(id);
+  docStatus.delete(id);
+  updateSubmitState();
+}
+
+async function processDoc(id, file) {
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+  try {
+    const res = await fetch('/api/process-document', { method: 'POST', body: formData });
+    const json = await res.json();
+    if (json.success) {
+      docTexts.set(id, { filename: json.filename, extracted_text: json.extracted_text });
+      docStatus.set(id, 'success');
+      renderChip(id, file.name, 'success');
+    } else {
+      docStatus.set(id, 'failed');
+      renderChip(id, file.name, 'failed', json.error || 'Processing failed');
+    }
+  } catch {
+    docStatus.set(id, 'failed');
+    renderChip(id, file.name, 'failed', 'Upload failed');
+  }
+  updateSubmitState();
+}
+
+function updateSubmitState() {
+  const hasPendingOrFailed = Array.from(docStatus.values()).some(s => s === 'pending' || s === 'failed');
+  const btn = document.getElementById('submit-btn');
+  if (hasPendingOrFailed) {
+    btn.disabled = true;
+    btn.classList.add('opacity-50', 'cursor-not-allowed');
+  } else {
+    btn.disabled = false;
+    btn.classList.remove('opacity-50', 'cursor-not-allowed');
+  }
+}
+
 // ── State ──────────────────────────────────────────────────────────────────
 let activeTab = 'vin', images = [], currentRunId = null, ws = null;
 let agentResults = {}, finalReport = null;
@@ -339,6 +461,8 @@ async function submitListing() {
     return showErr('Upload at least one photo, or describe damage in the notes field.');
 
   const imageUrls = fv('image_urls_text').split('\n').map(s => s.trim()).filter(Boolean);
+  const historyDocTexts = Array.from(docTexts.values())
+    .map(({ filename, extracted_text }) => '[Document: ' + filename + ']\n' + extracted_text);
   const body = {
     input_method: activeTab,
     mileage: +fv('mileage'), asking_price: +fv('asking_price'), location: fv('location'),
@@ -355,6 +479,7 @@ async function submitListing() {
     ...(fv('user_damage_notes') && { user_damage_notes: fv('user_damage_notes') }),
     ...(imageUrls.length && { image_urls: imageUrls }),
     ...(images.length && { image_base64: images }),
+    ...(historyDocTexts.length && { history_document_texts: historyDocTexts }),
   };
 
   document.getElementById('submit-btn').disabled = true;
@@ -625,6 +750,10 @@ function resetToForm() {
   document.getElementById('photo-label').textContent = 'Upload photos...';
   const lbl = document.getElementById('vin-confirmed-label');
   if (lbl) { lbl.textContent = ''; lbl.classList.add('hidden'); }
+  // clear document chips
+  docTexts.clear(); docStatus.clear();
+  document.getElementById('doc-chips').innerHTML = '';
+  updateSubmitState();
   showState('form');
 }
 

--- a/app/utils/document_processing.py
+++ b/app/utils/document_processing.py
@@ -57,6 +57,18 @@ def _extension(filename: str) -> str:
 async def _extract_via_haiku(content: bytes, media_type: str) -> str:
     client = get_anthropic_client()
     b64_data = base64.standard_b64encode(content).decode("utf-8")
+    # PDFs use the native document source type; images use the image source type.
+    content_block: dict = (
+        {
+            "type": "document",
+            "source": {"type": "base64", "media_type": media_type, "data": b64_data},
+        }
+        if media_type == "application/pdf"
+        else {
+            "type": "image",
+            "source": {"type": "base64", "media_type": media_type, "data": b64_data},
+        }
+    )
     response = await client.messages.create(  # type: ignore[call-overload]
         model=_HAIKU_MODEL,
         max_tokens=2048,
@@ -64,18 +76,8 @@ async def _extract_via_haiku(content: bytes, media_type: str) -> str:
             {
                 "role": "user",
                 "content": [
-                    {  # type: ignore[list-item]
-                        "type": "image",
-                        "source": {
-                            "type": "base64",
-                            "media_type": media_type,
-                            "data": b64_data,
-                        },
-                    },
-                    {
-                        "type": "text",
-                        "text": _HAIKU_PROMPT,
-                    },
+                    content_block,  # type: ignore[list-item]
+                    {"type": "text", "text": _HAIKU_PROMPT},
                 ],
             }
         ],
@@ -132,8 +134,8 @@ async def process_document(filename: str, content: bytes) -> ProcessedDocument:
                     error=None,
                 )
 
-            # pdfplumber returned empty (scanned PDF) — fall through to Haiku
-            extracted = await _extract_via_haiku(content, "image/jpeg")
+            # pdfplumber returned empty (scanned PDF) — fall through to Haiku using native PDF type
+            extracted = await _extract_via_haiku(content, "application/pdf")
         else:
             media_type = _MEDIA_TYPES[ext]
             extracted = await _extract_via_haiku(content, media_type)

--- a/app/utils/document_processing.py
+++ b/app/utils/document_processing.py
@@ -31,6 +31,7 @@ _HAIKU_PROMPT = (
 )
 
 _HAIKU_MODEL = "claude-haiku-4-5-20251001"
+_MAX_EXTRACTED_CHARS = 50_000
 
 
 class ProcessedDocument(TypedDict):
@@ -83,7 +84,7 @@ async def _extract_via_haiku(content: bytes, media_type: str) -> str:
         ],
     )
     text_blocks = [block.text for block in response.content if block.type == "text"]
-    return "\n".join(text_blocks).strip()
+    return "\n".join(text_blocks).strip().replace("\x00", "")[:_MAX_EXTRACTED_CHARS]
 
 
 async def _process_pdf(content: bytes) -> str:
@@ -95,7 +96,7 @@ async def _process_pdf(content: bytes) -> str:
             page_text = page.extract_text()
             if page_text:
                 text_parts.append(page_text)
-    return "\n".join(text_parts).strip()
+    return "\n".join(text_parts).strip().replace("\x00", "")[:_MAX_EXTRACTED_CHARS]
 
 
 # ---------------------------------------------------------------------------

--- a/app/utils/document_processing.py
+++ b/app/utils/document_processing.py
@@ -1,0 +1,156 @@
+"""Document processing pipeline — extract text from uploaded PDF and image files.
+
+Entry point: process_document(filename, content) -> ProcessedDocument
+"""
+
+from __future__ import annotations
+
+import base64
+from io import BytesIO
+from typing import TypedDict
+
+from app.core.llm import get_anthropic_client
+
+# ---------------------------------------------------------------------------
+# Output type
+# ---------------------------------------------------------------------------
+
+_SUPPORTED_EXTENSIONS = {".pdf", ".jpg", ".jpeg", ".png", ".webp"}
+
+_MEDIA_TYPES: dict[str, str] = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".webp": "image/webp",
+}
+
+_HAIKU_PROMPT = (
+    "Extract all vehicle history information from this document: "
+    "ownership records, accidents, repairs, mileage readings, title events, "
+    "odometer statements. Return only the extracted text."
+)
+
+_HAIKU_MODEL = "claude-haiku-4-5-20251001"
+
+
+class ProcessedDocument(TypedDict):
+    filename: str
+    format: str        # "pdf" | "image"
+    text: str          # empty string on failure
+    success: bool
+    error: str | None  # None on success
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extension(filename: str) -> str:
+    lower = filename.lower()
+    for ext in _SUPPORTED_EXTENSIONS:
+        if lower.endswith(ext):
+            return ext
+    return ""
+
+
+async def _extract_via_haiku(content: bytes, media_type: str) -> str:
+    client = get_anthropic_client()
+    b64_data = base64.standard_b64encode(content).decode("utf-8")
+    response = await client.messages.create(  # type: ignore[call-overload]
+        model=_HAIKU_MODEL,
+        max_tokens=2048,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {  # type: ignore[list-item]
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": media_type,
+                            "data": b64_data,
+                        },
+                    },
+                    {
+                        "type": "text",
+                        "text": _HAIKU_PROMPT,
+                    },
+                ],
+            }
+        ],
+    )
+    text_blocks = [block.text for block in response.content if block.type == "text"]
+    return "\n".join(text_blocks).strip()
+
+
+async def _process_pdf(content: bytes) -> str:
+    import pdfplumber  # noqa: PLC0415 — deferred so startup doesn't fail if missing
+
+    text_parts: list[str] = []
+    with pdfplumber.open(BytesIO(content)) as pdf:
+        for page in pdf.pages:
+            page_text = page.extract_text()
+            if page_text:
+                text_parts.append(page_text)
+    return "\n".join(text_parts).strip()
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def process_document(filename: str, content: bytes) -> ProcessedDocument:
+    ext = _extension(filename)
+
+    if ext not in _SUPPORTED_EXTENSIONS:
+        return ProcessedDocument(
+            filename=filename,
+            format="unknown",
+            text="",
+            success=False,
+            error=f"Unsupported file type: {ext or 'no extension'}",
+        )
+
+    is_pdf = ext == ".pdf"
+    doc_format = "pdf" if is_pdf else "image"
+
+    try:
+        if is_pdf:
+            try:
+                extracted = await _process_pdf(content)
+            except Exception:
+                extracted = ""
+
+            if extracted:
+                return ProcessedDocument(
+                    filename=filename,
+                    format=doc_format,
+                    text=extracted,
+                    success=True,
+                    error=None,
+                )
+
+            # pdfplumber returned empty (scanned PDF) — fall through to Haiku
+            extracted = await _extract_via_haiku(content, "image/jpeg")
+        else:
+            media_type = _MEDIA_TYPES[ext]
+            extracted = await _extract_via_haiku(content, media_type)
+
+        return ProcessedDocument(
+            filename=filename,
+            format=doc_format,
+            text=extracted,
+            success=True,
+            error=None,
+        )
+
+    except Exception as exc:
+        return ProcessedDocument(
+            filename=filename,
+            format=doc_format,
+            text="",
+            success=False,
+            error=str(exc)[:200],
+        )

--- a/app/utils/ingestion.py
+++ b/app/utils/ingestion.py
@@ -129,6 +129,28 @@ async def resolve_vin(listing: ListingInput) -> dict | None:
 # ---------------------------------------------------------------------------
 
 
+def _combine_history_text(listing: ListingInput) -> str | None:
+    """Merge history_report_text and history_document_texts into a single labeled string.
+
+    If history_document_texts is empty, returns history_report_text unchanged (may be None).
+    If documents are present, prepends a [User notes] section (when history_report_text is
+    non-empty) and appends each document entry separated by blank lines. Each entry in
+    history_document_texts is already pre-labeled by the frontend:
+        "[Document: filename.pdf]\\n{extracted_text}"
+    """
+    if not listing.history_document_texts:
+        return listing.history_report_text
+
+    parts: list[str] = []
+
+    if listing.history_report_text:
+        parts.append(f"[User notes]\n{listing.history_report_text}")
+
+    parts.extend(listing.history_document_texts)
+
+    return "\n\n".join(parts)
+
+
 async def prepare_listing(listing: ListingInput) -> tuple[ListingInput, list[str]]:
     """Normalise a raw ListingInput and return it alongside the prepared image list.
 
@@ -136,7 +158,8 @@ async def prepare_listing(listing: ListingInput) -> tuple[ListingInput, list[str
         (enriched_listing, base64_images)
 
         enriched_listing — original listing with year/make/model populated if VIN
-                           was provided and MCP resolution succeeded.
+                           was provided and MCP resolution succeeded, and with
+                           history_document_texts merged into history_report_text.
         base64_images    — flat list of base64-encoded image strings ready for
                            the Vision agent. May be empty if all fetches failed.
 
@@ -165,6 +188,14 @@ async def prepare_listing(listing: ListingInput) -> tuple[ListingInput, list[str
             enriched.make,
             enriched.model,
             enriched.trim or "not available",
+        )
+
+    combined_history = _combine_history_text(enriched)
+    if combined_history != enriched.history_report_text:
+        enriched = enriched.model_copy(update={"history_report_text": combined_history})
+        logger.info(
+            "Merged %d history document(s) into history_report_text",
+            len(listing.history_document_texts),
         )
 
     if not images:

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,5 +31,8 @@ httpx>=0.28.0
 # Image handling
 pillow>=11.1.0
 
+# PDF text extraction (pdfplumber is pure Python — no system packages required)
+pdfplumber>=0.11.0
+
 # Environment & utilities
 python-dotenv>=1.1.0


### PR DESCRIPTION
History agent document upload — Phase 2 of Iter 1.

Adds pdfplumber-based document processing with Haiku fallback for scanned PDFs, wires it into the API route and ingestion pipeline, and delivers the frontend chip list UI with async preprocessing and submit gating.