### PR TITLE
add Clerk auth backend — users table, JWT verification, webhook sync

### DIFF
--- a/alembic/versions/3dfad5854fb3_add_user_id_fk_to_analysis_runs.py
+++ b/alembic/versions/3dfad5854fb3_add_user_id_fk_to_analysis_runs.py
@@ -1,0 +1,38 @@
+"""add user_id fk to analysis_runs
+
+Revision ID: 3dfad5854fb3
+Revises: 724dc141ae14
+Create Date: 2026-06-01 22:30:49.384584
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '3dfad5854fb3'
+down_revision: Union[str, None] = '724dc141ae14'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        'analysis_runs',
+        sa.Column('user_id', sa.UUID(), nullable=True),
+    )
+    op.create_foreign_key(
+        'fk_analysis_runs_user_id',
+        'analysis_runs',
+        'users',
+        ['user_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint('fk_analysis_runs_user_id', 'analysis_runs', type_='foreignkey')
+    op.drop_column('analysis_runs', 'user_id')

--- a/alembic/versions/724dc141ae14_add_users_table.py
+++ b/alembic/versions/724dc141ae14_add_users_table.py
@@ -1,0 +1,34 @@
+"""add users table
+
+Revision ID: 724dc141ae14
+Revises: f6d406a9c7da
+Create Date: 2026-06-01 22:30:44.419273
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '724dc141ae14'
+down_revision: Union[str, None] = 'f6d406a9c7da'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'users',
+        sa.Column('id', sa.UUID(), nullable=False),
+        sa.Column('clerk_user_id', sa.String(), nullable=False),
+        sa.Column('email', sa.String(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('clerk_user_id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('users')

--- a/app/api/auth.py
+++ b/app/api/auth.py
@@ -1,0 +1,105 @@
+"""Clerk JWT verification as FastAPI dependencies.
+
+Two dependencies are provided:
+  get_optional_user — returns User | None; never raises on anonymous requests.
+  get_required_user — raises HTTP 401 if no authenticated user is present.
+
+JWKS key source is initialised once at FastAPI lifespan via init_jwks_client().
+PyJWKClient handles key caching and rotation transparently.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import jwt
+from fastapi import Depends, HTTPException, Request
+from jwt import PyJWKClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.session import get_db
+from app.models.db_models import User
+
+logger = logging.getLogger(__name__)
+
+# Module-level JWKS client — populated once at startup via init_jwks_client().
+# PyJWKClient handles key caching and transparent refresh on unknown key IDs,
+# so a single instance is safe across concurrent requests.
+_JWKS_CLIENT: PyJWKClient | None = None
+
+
+def init_jwks_client() -> None:
+    """Initialise the module-level JWKS client.
+
+    Called during FastAPI lifespan (after init_db, before yield).
+    Uses PyJWKClient with default caching (300 s JWK set TTL).
+    No network I/O at construction time — the first key fetch is deferred
+    until the first JWT verification attempt.
+    """
+    global _JWKS_CLIENT
+    _JWKS_CLIENT = PyJWKClient(settings.clerk_jwks_url)
+    logger.info("Clerk JWKS client initialised (url=%s)", settings.clerk_jwks_url)
+
+
+async def get_optional_user(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> User | None:
+    """Extract and verify a Clerk JWT from the Authorization header.
+
+    Returns the matching User row if the token is valid and the user exists
+    in the local database. Returns None in all other cases — missing header,
+    malformed token, expired token, invalid signature, or user not yet synced
+    via webhook. Never raises on anonymous requests.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        return None
+
+    token = auth_header.removeprefix("Bearer ").strip()
+    if not token:
+        return None
+
+    if _JWKS_CLIENT is None:
+        logger.warning("JWKS client not initialised — cannot verify JWT")
+        return None
+
+    try:
+        signing_key = _JWKS_CLIENT.get_signing_key_from_jwt(token)
+        payload = jwt.decode(
+            token,
+            signing_key.key,
+            algorithms=["RS256"],
+            options={"verify_aud": False},
+        )
+    except jwt.PyJWTError:
+        # Covers: ExpiredSignatureError, InvalidSignatureError, DecodeError, etc.
+        return None
+    except Exception:
+        # PyJWKClient network errors or unexpected failures — treat as unauthenticated.
+        logger.exception("Unexpected error during JWT verification")
+        return None
+
+    clerk_user_id: str | None = payload.get("sub")
+    if not clerk_user_id:
+        return None
+
+    user: User | None = await db.scalar(
+        select(User).where(User.clerk_user_id == clerk_user_id)
+    )
+    return user
+
+
+async def get_required_user(
+    user: User | None = Depends(get_optional_user),
+) -> User:
+    """Require an authenticated user.
+
+    Raises HTTP 401 if get_optional_user returns None.
+    Not used by any route in Phase 1a — implemented for Phase 2.
+    """
+    if user is None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return user

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -1,0 +1,141 @@
+"""Clerk webhook endpoint.
+
+Receives user lifecycle events from Clerk via Svix-signed POST requests.
+Syncs user.created and user.updated events to the local users table.
+
+Signature verification uses the svix library (official Clerk recommendation).
+If clerk_webhook_secret is empty, verification is skipped with a warning —
+this matches the admin_api_key pattern used elsewhere in the codebase.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from svix.webhooks import Webhook, WebhookVerificationError
+
+from app.core.config import settings
+from app.db.session import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["webhooks"])
+
+
+@router.post("/webhooks/clerk")
+async def clerk_webhook(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Handle Clerk user lifecycle webhook events.
+
+    Raw body is read before any JSON parsing so the Svix signature covers
+    the exact bytes Clerk sent. Event types handled:
+      user.created  — upsert into users (idempotent; Clerk may replay events)
+      user.updated  — update email where clerk_user_id matches
+    All other event types return 200 with status: ignored.
+    """
+    body: bytes = await request.body()
+
+    if not settings.clerk_webhook_secret:
+        logger.warning(
+            "clerk_webhook_secret is empty — skipping webhook signature verification"
+        )
+    else:
+        headers_dict: dict[str, str] = {
+            "svix-id": request.headers.get("svix-id", ""),
+            "svix-timestamp": request.headers.get("svix-timestamp", ""),
+            "svix-signature": request.headers.get("svix-signature", ""),
+        }
+        try:
+            Webhook(settings.clerk_webhook_secret).verify(body, headers_dict)
+        except WebhookVerificationError:
+            raise HTTPException(status_code=400, detail="Invalid webhook signature")
+
+    try:
+        payload: dict = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON payload")
+
+    event_type: str = payload.get("type", "")
+    data: dict = payload.get("data", {})
+
+    if event_type == "user.created":
+        await _handle_user_created(db, data)
+    elif event_type == "user.updated":
+        await _handle_user_updated(db, data)
+    else:
+        return {"status": "ignored"}
+
+    return {"status": "ok"}
+
+
+def _extract_primary_email(data: dict) -> str:
+    """Extract the primary email address from a Clerk user payload.
+
+    Clerk sends email_addresses as a list; the primary one is identified by
+    primary_email_address_id matching the id field on an email address object.
+    Falls back to the first address in the list if no primary is marked.
+    Returns an empty string if no email addresses are present.
+    """
+    email_addresses: list[dict] = data.get("email_addresses", [])
+    if not email_addresses:
+        return ""
+
+    primary_id: str = data.get("primary_email_address_id", "")
+    for addr in email_addresses:
+        if addr.get("id") == primary_id:
+            return addr.get("email_address", "")
+
+    # Fallback: use the first address
+    return email_addresses[0].get("email_address", "")
+
+
+async def _handle_user_created(db: AsyncSession, data: dict) -> None:
+    """Upsert a user row on user.created.
+
+    Uses INSERT ... ON CONFLICT (clerk_user_id) DO UPDATE so that Clerk
+    event replays are idempotent — replaying user.created is safe.
+    """
+    clerk_user_id: str = data.get("id", "")
+    email: str = _extract_primary_email(data)
+
+    if not clerk_user_id:
+        logger.warning("user.created event missing id field — skipping")
+        return
+
+    await db.execute(
+        text(
+            """
+            INSERT INTO users (id, clerk_user_id, email, created_at)
+            VALUES (gen_random_uuid(), :clerk_user_id, :email, now())
+            ON CONFLICT (clerk_user_id) DO UPDATE SET email = EXCLUDED.email
+            """
+        ),
+        {"clerk_user_id": clerk_user_id, "email": email},
+    )
+    await db.commit()
+    logger.info("user.created processed: clerk_user_id=%s", clerk_user_id)
+
+
+async def _handle_user_updated(db: AsyncSession, data: dict) -> None:
+    """Update email on user.updated."""
+    clerk_user_id: str = data.get("id", "")
+    email: str = _extract_primary_email(data)
+
+    if not clerk_user_id:
+        logger.warning("user.updated event missing id field — skipping")
+        return
+
+    await db.execute(
+        text(
+            "UPDATE users SET email = :email WHERE clerk_user_id = :clerk_user_id"
+        ),
+        {"clerk_user_id": clerk_user_id, "email": email},
+    )
+    await db.commit()
+    logger.info("user.updated processed: clerk_user_id=%s", clerk_user_id)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -26,6 +26,12 @@ class Settings(BaseSettings):
     # Set a strong random value in .env; empty string disables admin endpoints
     admin_api_key: str = ""
 
+    # Clerk auth — JWT verification and webhook signature
+    # clerk_jwks_url: Clerk JWKS endpoint; default is the standard Clerk URL
+    clerk_jwks_url: str = "https://api.clerk.com/v1/jwks"
+    # clerk_webhook_secret: set in .env; empty string skips verification with a warning
+    clerk_webhook_secret: str = ""
+
     debug: bool = False
 
 

--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,9 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 from app.api.admin import router as admin_router
+from app.api.auth import init_jwks_client
 from app.api.routes import router
+from app.api.webhooks import router as webhooks_router
 from app.api.websocket import router as ws_router
 from app.core.logging import configure_logging
 from app.db.init_db import init_db
@@ -23,6 +25,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     logger.info("Starting up — initialising database")
     await init_db()
     logger.info("Database ready")
+    init_jwks_client()
     yield
     logger.info("Shutting down")
 
@@ -34,6 +37,7 @@ app.mount("/static", StaticFiles(directory="app/static"), name="static")
 app.include_router(router)
 app.include_router(admin_router)
 app.include_router(ws_router)
+app.include_router(webhooks_router)
 
 
 @app.get("/")

--- a/app/models/db_models.py
+++ b/app/models/db_models.py
@@ -67,6 +67,36 @@ class RecommendationEnum(str, enum.Enum):
 
 
 # ---------------------------------------------------------------------------
+# User
+# ---------------------------------------------------------------------------
+
+
+class User(Base):
+    """Identity record synced from Clerk via webhook.
+
+    clerk_user_id is the primary external identifier — it is what Clerk sends in
+    JWT sub claims and webhook payloads. email is stored for display purposes only;
+    Clerk is the authoritative source of truth for user identity.
+    """
+
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    clerk_user_id: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    email: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    # Relationship — lazy load is fine; runs are fetched independently
+    analysis_runs: Mapped[list[AnalysisRun]] = relationship(
+        "AnalysisRun", back_populates="user", lazy="select"
+    )
+
+
+# ---------------------------------------------------------------------------
 # AnalysisRun
 # ---------------------------------------------------------------------------
 
@@ -87,8 +117,15 @@ class AnalysisRun(Base):
     listing_input: Mapped[dict] = mapped_column(JSONB, nullable=False)
     # Complete serialized FinalReport — written on completion, read for late-joining WS clients
     full_result: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    # Nullable — anonymous runs (no auth) have user_id = NULL; ON DELETE SET NULL so runs survive user deletion
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     # Relationships
+    user: Mapped[User | None] = relationship("User", back_populates="analysis_runs")
     agent_results: Mapped[list[AgentResult]] = relationship(
         "AgentResult", back_populates="run", cascade="all, delete-orphan"
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,5 +34,9 @@ pillow>=11.1.0
 # PDF text extraction (pdfplumber is pure Python — no system packages required)
 pdfplumber>=0.11.0
 
+# Clerk auth — JWT verification and webhook signature
+PyJWT>=2.9.0
+svix>=1.0.0
+
 # Environment & utilities
 python-dotenv>=1.1.0

--- a/tests/test_document_processing.py
+++ b/tests/test_document_processing.py
@@ -6,8 +6,7 @@ the routing logic and error handling, not the accuracy of OCR output.
 
 from __future__ import annotations
 
-from io import BytesIO
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 

--- a/tests/test_finance_computation.py
+++ b/tests/test_finance_computation.py
@@ -10,13 +10,12 @@ from __future__ import annotations
 import pytest
 
 from app.agents.finance import (
-    ANNUAL_MAINTENANCE_BASE,
     _PAINT_COMPLEXITY_MULTIPLIER,
+    ANNUAL_MAINTENANCE_BASE,
     _annual_maintenance,
     _compute_finance_score,
     _monthly_payment,
 )
-
 
 # ---------------------------------------------------------------------------
 # _compute_finance_score

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import base64
 import io
-import uuid
 from unittest.mock import AsyncMock, patch
 
 import pytest


### PR DESCRIPTION
## Summary

- Adds `users` table (clerk_user_id, email, created_at) via two hand-written Alembic migrations — users table first, then nullable `user_id` FK on `analysis_runs` (ON DELETE SET NULL)
- `app/api/auth.py`: `get_optional_user` / `get_required_user` FastAPI dependencies; PyJWKClient fetched once at lifespan startup, RS256 verification per request; returns `User | None`, never raises on anonymous requests
- `app/api/webhooks.py`: `POST /webhooks/clerk` with Svix signature verification; handles `user.created` (idempotent upsert) and `user.updated` (email sync); all other event types return 200/ignored
- Anonymous-first: no existing routes touched, all auth is additive

## Test plan

- [ ] CI passes (ruff + mypy + pytest)
- [ ] `alembic upgrade head` applies both migrations cleanly against a fresh DB
- [ ] `POST /webhooks/clerk` with invalid signature returns 400
- [ ] `POST /webhooks/clerk` with valid `user.created` payload inserts a user row
- [ ] `POST /webhooks/clerk` with duplicate `user.created` replays cleanly (upsert)
- [ ] Request without `Authorization` header to any existing route still returns 200 (anonymous flow unbroken)